### PR TITLE
All file names are not valid global properties identifiers.

### DIFF
--- a/returnExports.js
+++ b/returnExports.js
@@ -24,7 +24,8 @@
         // AMD. Register as an anonymous module.
         define(['b'], factory);
     } else {
-        // Browser globals
+        // Browser globals. If returnExports string is not a valid JS identifier,
+        // eg return-exports, use root['return-exports']
         root.returnExports = factory(root.b);
     }
 }(this, function (b) {


### PR DESCRIPTION
The match between file names and global var names stumbles if the file name has a dash.
