### PR TITLE
Incorrect checks for node

### DIFF
--- a/nodeAdapter.js
+++ b/nodeAdapter.js
@@ -9,8 +9,8 @@
 // with a circular dependency, see commonjsAdapter.js
 
 // Help Node out by setting up define.
-if (typeof exports === 'object' && typeof define !== 'function') {
-    define = function (factory) {
+if (typeof module === 'object' && typeof define !== 'function') {
+    var define = function (factory) {
         module.exports = factory(require, exports, module);
     };
 }


### PR DESCRIPTION
module will be the correct object to be checking the existence of. 

Not using 'var define' hoists function out of the if block making 'define' defined as a function making that check a double fail.
