### PR TITLE
add pattern that doesn't require a dependency to returnExports

### DIFF
--- a/returnExports.js
+++ b/returnExports.js
@@ -24,11 +24,34 @@
         // AMD. Register as an anonymous module.
         define(['b'], factory);
     } else {
-        // Browser globals
+        // Browser globals (root is window)
         root.returnExports = factory(root.b);
     }
 }(this, function (b) {
     //use b in some fashion.
+
+    // Just return a value to define the module export.
+    // This example returns an object, but the module
+    // can return a function as the exported value.
+    return {};
+}));
+
+
+// if the module has no dependencies, the above pattern can be simplified to
+(function (root, factory) {
+    if (typeof exports === 'object') {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like enviroments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(factory);
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory();
+  }
+}(this, function () {
 
     // Just return a value to define the module export.
     // This example returns an object, but the module


### PR DESCRIPTION
These things are so esoteric, it always takes me a few minutes to tease them apart.  It'd be nice to have this variation listed.
