### PR TITLE
put the AMD definitions before CommonJS

### DIFF
--- a/commonjsStrict.js
+++ b/commonjsStrict.js
@@ -17,12 +17,12 @@
 // the top function.
 
 (function (root, factory) {
-    if (typeof exports === 'object') {
-        // CommonJS
-        factory(exports, require('b'));
-    } else if (typeof define === 'function' && define.amd) {
+    if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['exports', 'b'], factory);
+    } else if (typeof exports === 'object') {
+        // CommonJS
+        factory(exports, require('b'));
     } else {
         // Browser globals
         factory((root.commonJsStrict = {}), root.b);

--- a/commonjsStrictGlobal.js
+++ b/commonjsStrictGlobal.js
@@ -17,14 +17,14 @@
 // in the browser, it will create a global .b that is used below.
 
 (function (root, factory) {
-    if (typeof exports === 'object') {
-        // CommonJS
-        factory(exports, require('b'));
-    } else if (typeof define === 'function' && define.amd) {
+    if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['exports', 'b'], function (exports, b) {
             factory((root.commonJsStrictGlobal = exports), b);
         });
+    } else if (typeof exports === 'object') {
+        // CommonJS
+        factory(exports, require('b'));
     } else {
         // Browser globals
         factory((root.commonJsStrictGlobal = {}), root.b);

--- a/jqueryPluginCommonjs.js
+++ b/jqueryPluginCommonjs.js
@@ -7,12 +7,12 @@
 // not want to add the extra CommonJS detection.
 
 (function (factory) {
-    if (typeof exports === 'object') {
-        // Node/CommonJS
-        factory(require('jquery'));
-    } else if (typeof define === 'function' && define.amd) {
+    if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['jquery'], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS
+        factory(require('jquery'));
     } else {
         // Browser globals
         factory(jQuery);

--- a/returnExports.js
+++ b/returnExports.js
@@ -15,14 +15,14 @@
 // the top function.
 
 (function (root, factory) {
-    if (typeof exports === 'object') {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['b'], factory);
+    } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like enviroments that support module.exports,
         // like Node.
         module.exports = factory(require('b'));
-    } else if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['b'], factory);
     } else {
         // Browser globals (root is window)
         root.returnExports = factory(root.b);
@@ -39,14 +39,14 @@
 
 // if the module has no dependencies, the above pattern can be simplified to
 (function (root, factory) {
-    if (typeof exports === 'object') {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(factory);
+    } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like enviroments that support module.exports,
         // like Node.
         module.exports = factory();
-    } else if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(factory);
     } else {
         // Browser globals (root is window)
         root.returnExports = factory();

--- a/returnExportsGlobal.js
+++ b/returnExportsGlobal.js
@@ -15,16 +15,16 @@
 // in the browser, it will create a global .b that is used below.
 
 (function (root, factory) {
-    if (typeof exports === 'object') {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like enviroments that support module.exports,
-        // like Node.
-        module.exports = factory(require('b'));
-    } else if (typeof define === 'function' && define.amd) {
+    if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['b'], function (b) {
             return (root.returnExportsGlobal = factory(b));
         });
+    } else if (typeof exports === 'object') {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like enviroments that support module.exports,
+        // like Node.
+        module.exports = factory(require('b'));
     } else {
         // Browser globals
         root.returnExportsGlobal = factory(root.b);


### PR DESCRIPTION
Some build tools expose an `exports` object.  UMDs that check for `exports` first will cause those build tools to error out.
