### PR TITLE
define call should include empty dependencies list

### DIFF
--- a/returnExports.js
+++ b/returnExports.js
@@ -41,7 +41,7 @@
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define(factory);
+        define([], factory);
     } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like enviroments that support module.exports,


### PR DESCRIPTION
Without this, the factory may be scanned for additional dependencies matching the literal string `require("module-id")`, which is not correct. See https://github.com/amdjs/amdjs-api/wiki/AMD#simplified-commonjs-wrapping-.
