### PR TITLE
root.returnExports into returnExports

### DIFF
--- a/returnExports.js
+++ b/returnExports.js
@@ -24,8 +24,8 @@
         // like Node.
         module.exports = factory(require('b'));
     } else {
-        // Browser globals (root is window)
-        root.returnExports = factory(root.b);
+        // Environment global (Browsers, WSH, ASP)
+        returnExports = factory(root.b);
     }
 }(this, function (b) {
     //use b in some fashion.


### PR DESCRIPTION
While `this` points to the global object (window in browsers and Global in WSH), it doesn't work in ASP. So, by removing the `root.` from `root.returnExports` it works as its intended to.