### PR TITLE
Fix issue #48

### DIFF
--- a/nodeAdapter.js
+++ b/nodeAdapter.js
@@ -8,15 +8,17 @@
 // that do not support module.exports or if you want to define a module
 // with a circular dependency, see commonjsAdapter.js
 
-// Help Node out by setting up define.
-if (typeof module === 'object' && typeof define !== 'function') {
-    var define = function (factory) {
-        module.exports = factory(require, exports, module);
-    };
-}
+(function(define) {
+    
+    define(function (require, exports, module) {
+        var b = require('b');
 
-define(function (require, exports, module) {
-    var b = require('b');
+        return function () {};
+    });
+    
+})( // Help Node out by setting up define.
+     typeof module === 'object' && typeof define !== 'function'
+    ? function (factory) { module.exports = factory(require, exports, module); } 
+    : define
+);
 
-    return function () {};
-});

--- a/nodeAdapter.js
+++ b/nodeAdapter.js
@@ -16,9 +16,9 @@
         return function () {};
     });
     
-})( // Help Node out by setting up define.
+}( // Help Node out by setting up define.
      typeof module === 'object' && typeof define !== 'function'
     ? function (factory) { module.exports = factory(require, exports, module); } 
     : define
-);
+));
 


### PR DESCRIPTION
Wrap `define` in a self-invoked function.

I like this style because it keeps each scope clean and avoids `var`