### PR TITLE
In Node/CommonJS, actually use the thing that factory exposes.

### DIFF
--- a/jqueryPluginCommonjs.js
+++ b/jqueryPluginCommonjs.js
@@ -9,7 +9,7 @@
         define(['jquery'], factory);
     } else if (typeof exports === 'object') {
         // Node/CommonJS
-        factory(require('jquery'));
+        module.exports = factory(require('jquery'));
     } else {
         // Browser globals
         factory(jQuery);


### PR DESCRIPTION
useful for the scenario where a jQuery plugin augments the jQuery object, but also exposes some-other-API/some-other-stuff.