### PR TITLE
Defines module names

### DIFF
--- a/amdWeb.js
+++ b/amdWeb.js
@@ -16,12 +16,13 @@
 // the top function.
 
 (function (root, factory) {
+    var moduleName = 'amdWeb';
     if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['b'], factory);
+        // AMD
+        define(moduleName, ['b'], factory);
     } else {
         // Browser globals
-        root.amdWeb = factory(root.b);
+        root[moduleName] = factory(root.b);
     }
 }(this, function (b) {
     //use b in some fashion.

--- a/amdWebGlobal.js
+++ b/amdWebGlobal.js
@@ -16,17 +16,18 @@
 // in the browser, it will create a global .b that is used below.
 
 (function (root, factory) {
+    var moduleName = 'amdWebGlobal';
     if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['b'], function (b) {
+        // AMD
+        define(moduleName, ['b'], function (b) {
             // Also create a global in case some scripts
             // that are loaded still are looking for
             // a global even when an AMD loader is in use.
-            return (root.amdWebGlobal = factory(b));
+            return (root[moduleName] = factory(b));
         });
     } else {
         // Browser globals
-        root.amdWebGlobal = factory(root.b);
+        root[moduleName] = factory(root.b);
     }
 }(this, function (b) {
     //use b in some fashion.

--- a/commonjsStrict.js
+++ b/commonjsStrict.js
@@ -5,7 +5,7 @@
 // circular dependency, then see returnExports.js instead. It will allow
 // you to export a function as the module value.
 
-// Defines a module "commonJsStrict" that depends another module called "b".
+// Defines a module "commonjsStrict" that depends another module called "b".
 // Note that the name of the module is implied by the file name. It is best
 // if the file name and the exported global have matching names.
 
@@ -17,15 +17,16 @@
 // the top function.
 
 (function (root, factory) {
+    var moduleName = "commonjsStrict";
     if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['exports', 'b'], factory);
+        // AMD
+        define(moduleName, ['exports', 'b'], factory);
     } else if (typeof exports === 'object') {
         // CommonJS
         factory(exports, require('b'));
     } else {
         // Browser globals
-        factory((root.commonJsStrict = {}), root.b);
+        factory((root[moduleName] = {}), root.b);
     }
 }(this, function (exports, b) {
     //use b in some fashion.

--- a/commonjsStrictGlobal.js
+++ b/commonjsStrictGlobal.js
@@ -9,7 +9,7 @@
 // circular dependency, then see returnExportsGlobal.js instead. It will allow
 // you to export a function as the module value.
 
-// Defines a module "commonJsStrictGlobal" that depends another module called
+// Defines a module "commonjsStrictGlobal" that depends another module called
 // "b". Note that the name of the module is implied by the file name. It is
 // best if the file name and the exported global have matching names.
 
@@ -17,17 +17,18 @@
 // in the browser, it will create a global .b that is used below.
 
 (function (root, factory) {
+    var moduleName = 'commonjsStrictGlobal';
     if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['exports', 'b'], function (exports, b) {
-            factory((root.commonJsStrictGlobal = exports), b);
+        // AMD
+        define(moduleName, ['exports', 'b'], function (exports, b) {
+            factory((root[moduleName] = exports), b);
         });
     } else if (typeof exports === 'object') {
         // CommonJS
         factory(exports, require('b'));
     } else {
         // Browser globals
-        factory((root.commonJsStrictGlobal = {}), root.b);
+        factory((root[moduleName] = {}), root.b);
     }
 }(this, function (exports, b) {
     //use b in some fashion.

--- a/returnExports.js
+++ b/returnExports.js
@@ -15,9 +15,10 @@
 // the top function.
 
 (function (root, factory) {
+    var moduleName = 'returnExports';
     if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['b'], factory);
+        // AMD
+        define(moduleName, ['b'], factory);
     } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like environments that support module.exports,
@@ -25,7 +26,7 @@
         module.exports = factory(require('b'));
     } else {
         // Browser globals (root is window)
-        root.returnExports = factory(root.b);
+        root[moduleName] = factory(root.b);
     }
 }(this, function (b) {
     //use b in some fashion.
@@ -39,9 +40,10 @@
 
 // if the module has no dependencies, the above pattern can be simplified to
 (function (root, factory) {
+    var moduleName = 'returnExports';
     if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define([], factory);
+        // AMD
+        define(moduleName, [], factory);
     } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like environments that support module.exports,
@@ -49,7 +51,7 @@
         module.exports = factory();
     } else {
         // Browser globals (root is window)
-        root.returnExports = factory();
+        root[moduleName] = factory();
   }
 }(this, function () {
 

--- a/returnExportsGlobal.js
+++ b/returnExportsGlobal.js
@@ -15,10 +15,11 @@
 // in the browser, it will create a global .b that is used below.
 
 (function (root, factory) {
+    var moduleName = 'returnExportsGlobal';
     if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['b'], function (b) {
-            return (root.returnExportsGlobal = factory(b));
+        // AMD
+        define(moduleName, ['b'], function (b) {
+            return (root[moduleName] = factory(b));
         });
     } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
@@ -27,7 +28,7 @@
         module.exports = factory(require('b'));
     } else {
         // Browser globals
-        root.returnExportsGlobal = factory(root.b);
+        root[moduleName] = factory(root.b);
     }
 }(this, function (b) {
     //use b in some fashion.


### PR DESCRIPTION
Currently, AMD modules are defined anonymously, which is not always the use case, and the exposed browser global is defined in one or two places in each loader. This could led to inconsistencies or errors by simply misspelling any of those names. So, to ensure consistency it is better to write it down in only one place, i.e.: in a variable at the beginning of the loader.

This PR defines that variable holding the module name and uses it to to name the AMD module and set the proper browser global variables.
