### PR TITLE
add name vars

### DIFF
--- a/amdWeb.js
+++ b/amdWeb.js
@@ -16,12 +16,13 @@
 // the top function.
 
 (function (root, factory) {
+    var name = 'amdWeb';
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['b'], factory);
     } else {
         // Browser globals
-        root.amdWeb = factory(root.b);
+        root[name] = factory(root.b);
     }
 }(this, function (b) {
     //use b in some fashion.

--- a/amdWebGlobal.js
+++ b/amdWebGlobal.js
@@ -16,17 +16,18 @@
 // in the browser, it will create a global .b that is used below.
 
 (function (root, factory) {
+    var name = 'amdWebGlobal';
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['b'], function (b) {
             // Also create a global in case some scripts
             // that are loaded still are looking for
             // a global even when an AMD loader is in use.
-            return (root.amdWebGlobal = factory(b));
+            return (root[name] = factory(b));
         });
     } else {
         // Browser globals
-        root.amdWebGlobal = factory(root.b);
+        root[name] = factory(root.b);
     }
 }(this, function (b) {
     //use b in some fashion.

--- a/commonjsStrict.js
+++ b/commonjsStrict.js
@@ -17,6 +17,7 @@
 // the top function.
 
 (function (root, factory) {
+    var name = 'commonJsStrict';
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['exports', 'b'], factory);
@@ -25,7 +26,7 @@
         factory(exports, require('b'));
     } else {
         // Browser globals
-        factory((root.commonJsStrict = {}), root.b);
+        factory((root[name] = {}), root.b);
     }
 }(this, function (exports, b) {
     //use b in some fashion.

--- a/commonjsStrictGlobal.js
+++ b/commonjsStrictGlobal.js
@@ -17,17 +17,18 @@
 // in the browser, it will create a global .b that is used below.
 
 (function (root, factory) {
+    var name = 'commonJsStrictGlobal';
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['exports', 'b'], function (exports, b) {
-            factory((root.commonJsStrictGlobal = exports), b);
+            factory((root[name] = exports), b);
         });
     } else if (typeof exports === 'object') {
         // CommonJS
         factory(exports, require('b'));
     } else {
         // Browser globals
-        factory((root.commonJsStrictGlobal = {}), root.b);
+        factory((root[name] = {}), root.b);
     }
 }(this, function (exports, b) {
     //use b in some fashion.

--- a/returnExports.js
+++ b/returnExports.js
@@ -15,6 +15,7 @@
 // the top function.
 
 (function (root, factory) {
+    var name = 'returnExports';
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['b'], factory);
@@ -25,7 +26,7 @@
         module.exports = factory(require('b'));
     } else {
         // Browser globals (root is window)
-        root.returnExports = factory(root.b);
+        root[name] = factory(root.b);
     }
 }(this, function (b) {
     //use b in some fashion.
@@ -39,6 +40,7 @@
 
 // if the module has no dependencies, the above pattern can be simplified to
 (function (root, factory) {
+    var name = 'returnExports';
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(factory);
@@ -49,7 +51,7 @@
         module.exports = factory();
     } else {
         // Browser globals (root is window)
-        root.returnExports = factory();
+        root[name] = factory();
   }
 }(this, function () {
 

--- a/returnExportsGlobal.js
+++ b/returnExportsGlobal.js
@@ -15,10 +15,11 @@
 // in the browser, it will create a global .b that is used below.
 
 (function (root, factory) {
+    var name = 'returnExportsGlobal';
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['b'], function (b) {
-            return (root.returnExportsGlobal = factory(b));
+            return (root[name] = factory(b));
         });
     } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
@@ -27,7 +28,7 @@
         module.exports = factory(require('b'));
     } else {
         // Browser globals
-        root.returnExportsGlobal = factory(root.b);
+        root[name] = factory(root.b);
     }
 }(this, function (b) {
     //use b in some fashion.


### PR DESCRIPTION
Adds `name` variables to applicable examples/boilerplates, replacing repeated hard-coded `root` assignments. This makes them a little more [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself), and therefore easier for users to modify after copy/paste when creating new modules.
