### PR TITLE
Typo fixes

### DIFF
--- a/amdWeb.js
+++ b/amdWeb.js
@@ -4,7 +4,7 @@
 // If you want to support other stricter CommonJS environments,
 // or if you need to create a circular dependency, see commonJsStrict.js
 
-// Defines a module "amdWeb" that depends another module called "b".
+// Defines a module "amdWeb" that depends on another module called "b".
 // Note that the name of the module is implied by the file name. It is best
 // if the file name and the exported global have matching names.
 
@@ -12,7 +12,7 @@
 // in the browser, it will create a global .b that is used below.
 
 // If you do not want to support the browser global path, then you
-// can remove the `root` use and the passing `this` as the first arg to
+// can remove the `root` use and the passing of `this` as the first arg to
 // the top function.
 
 (function (root, factory) {


### PR DESCRIPTION
This is among the most common JS module formats on the web, and in 4 years, nobody fixed those typos?