### PR TITLE
Semicolons before immediately executed functions

### DIFF
--- a/amdWeb.js
+++ b/amdWeb.js
@@ -15,7 +15,7 @@
 // can remove the `root` use and the passing of `this` as the first arg to
 // the top function.
 
-(function (root, factory) {
+;(function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['b'], factory);

--- a/amdWebGlobal.js
+++ b/amdWebGlobal.js
@@ -15,7 +15,7 @@
 // If the 'b' module also uses this type of boilerplate, then
 // in the browser, it will create a global .b that is used below.
 
-(function (root, factory) {
+;(function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['b'], function (b) {

--- a/commonjsStrict.js
+++ b/commonjsStrict.js
@@ -16,7 +16,7 @@
 // can remove the `root` use and the passing `this` as the first arg to
 // the top function.
 
-(function (root, factory) {
+;(function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['exports', 'b'], factory);

--- a/commonjsStrictGlobal.js
+++ b/commonjsStrictGlobal.js
@@ -16,7 +16,7 @@
 // If the 'b' module also uses this type of boilerplate, then
 // in the browser, it will create a global .b that is used below.
 
-(function (root, factory) {
+;(function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['exports', 'b'], function (exports, b) {

--- a/jqueryPlugin.js
+++ b/jqueryPlugin.js
@@ -4,7 +4,7 @@
 // jQuery is not likely to run in those environments.
 // See jqueryPluginCommonJs.js for that version.
 
-(function (factory) {
+;(function (factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['jquery'], factory);

--- a/jqueryPluginCommonjs.js
+++ b/jqueryPluginCommonjs.js
@@ -3,7 +3,7 @@
 // Similar to jqueryPlugin.js but also tries to
 // work in a CommonJS environment.
 
-(function (factory) {
+;(function (factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['jquery'], factory);

--- a/nodeAdapter.js
+++ b/nodeAdapter.js
@@ -8,7 +8,7 @@
 // that do not support module.exports or if you want to define a module
 // with a circular dependency, see commonjsAdapter.js
 
-(function(define) {
+;(function(define) {
 
     define(function (require, exports, module) {
         var b = require('b');
@@ -21,4 +21,3 @@
     ? function (factory) { module.exports = factory(require, exports, module); }
     : define
 ));
-

--- a/returnExports.js
+++ b/returnExports.js
@@ -14,7 +14,7 @@
 // can remove the `root` use and the passing `this` as the first arg to
 // the top function.
 
-(function (root, factory) {
+;(function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['b'], factory);
@@ -38,7 +38,7 @@
 
 
 // if the module has no dependencies, the above pattern can be simplified to
-(function (root, factory) {
+;(function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define([], factory);

--- a/returnExportsGlobal.js
+++ b/returnExportsGlobal.js
@@ -14,7 +14,7 @@
 // If the 'b' module also uses this type of boilerplate, then
 // in the browser, it will create a global .b that is used below.
 
-(function (root, factory) {
+;(function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['b'], function (b) {


### PR DESCRIPTION
Adding semicolons before all immediately executed functions makes UMD safe in concatenation scenarios. Without the initial semicolon in UMD, a file not ending with a semicolon (A) concatenated with a file using UMD (B) might be parsed in an unexpected way:

```
var foo = 'bar' // File A
(function () { /* UMD */ }()); // File B
// TypeError: string is not a function
```
```
var foo = 'bar' // File A
;(function () { /* UMD */ }()); // File B
// good
```