### PR TITLE
Easier ternary operator construction

### DIFF
--- a/templates/nodeAdapter.js
+++ b/templates/nodeAdapter.js
@@ -17,8 +17,8 @@
     });
 
 }( // Help Node out by setting up define.
-    typeof module === 'object' && module.exports && typeof define !== 'function' ?
-    function (factory) { module.exports = factory(require, exports, module); } :
-    define
+    typeof module === 'object' && module.exports && typeof define !== 'function'
+      ? function (factory) { module.exports = factory(require, exports, module); }
+      : define
 ));
 


### PR DESCRIPTION
Make it easy to figure what are the possible return values from the ternary construction that provides the value of `define` parameter of the module's closure, improving the experience of learning the pattern.
