### PR TITLE
Fix README headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##UMD (Universal Module Definition)
+## UMD (Universal Module Definition)
 
 [![Build Status](https://travis-ci.org/umdjs/umd.svg)](https://travis-ci.org/umdjs/umd)
 
@@ -8,7 +8,7 @@ The UMD pattern typically attempts to offer compatibility with the most popular 
 
 ### Variations
 
-####Regular Module
+#### Regular Module
 
 * [amdWeb.js](https://github.com/umdjs/umd/blob/master/templates/amdWeb.js) -
   Defines a module that works with AMD and browser globals. If you also want
@@ -27,12 +27,12 @@ The UMD pattern typically attempts to offer compatibility with the most popular 
   scripts that still expect that global), use
   [commonjsStrictGlobal.js](https://github.com/umdjs/umd/blob/master/templates/commonjsStrictGlobal.js)
 
-####jQuery Plugin
+#### jQuery Plugin
 
 * [jqueryPlugin.js](https://github.com/umdjs/umd/blob/master/templates/jqueryPlugin.js) -
   Defines a jQuery plugin that works with AMD and browser globals.
 
-####AMD with simple Node/CommonJS adapter
+#### AMD with simple Node/CommonJS adapter
 
 These are useful for using AMD style while still making modules that can be
 used in Node and installed via npm without extra dependencies to set up the
@@ -65,11 +65,11 @@ is usable in AMD.
 
 * [Unit testing UMD with grunt-contrib-jasmine](http://stackoverflow.com/questions/16940548/grunt-test-for-umd)
 
-###Resources
+### Resources
 
 * [Browserify and the Universal Module Definition](http://dontkry.com/posts/code/browserify-and-the-universal-module-definition.html)
 
-###Todos
+### Todos
 
 * noConflict. Although with AMD loaders and build tools, it should be possible to get version specific bindings,
   maybe show a version that has a noConflict option.


### PR DESCRIPTION
GitHub Markdown now requires a space after the `#` headers. Couldn't find a good reference to when this changed, but it's prevalent in all the documentation. 

[GitHub Markdown Guide > Basic writing and formatting syntax > Headings](https://help.github.com/articles/basic-writing-and-formatting-syntax/#headings)