### PR TITLE
Explicitly detect browser global in strict mode.

### DIFF
--- a/templates/amdWeb.js
+++ b/templates/amdWeb.js
@@ -23,7 +23,7 @@
         // Browser globals
         root.amdWeb = factory(root.b);
     }
-}(this, function (b) {
+}(typeof window !== 'undefined' ? window : this, function (b) {
     // Use b in some fashion.
 
     // Just return a value to define the module export.

--- a/templates/amdWeb.js
+++ b/templates/amdWeb.js
@@ -23,7 +23,7 @@
         // Browser globals
         root.amdWeb = factory(root.b);
     }
-}(typeof window !== 'undefined' ? window : this, function (b) {
+}(typeof self !== 'undefined' ? self : this, function (b) {
     // Use b in some fashion.
 
     // Just return a value to define the module export.

--- a/templates/amdWebGlobal.js
+++ b/templates/amdWebGlobal.js
@@ -28,7 +28,7 @@
         // Browser globals
         root.amdWebGlobal = factory(root.b);
     }
-}(this, function (b) {
+}(typeof window !== 'undefined' ? window : this, function (b) {
     // Use b in some fashion.
 
     // Just return a value to define the module export.

--- a/templates/amdWebGlobal.js
+++ b/templates/amdWebGlobal.js
@@ -28,7 +28,7 @@
         // Browser globals
         root.amdWebGlobal = factory(root.b);
     }
-}(typeof window !== 'undefined' ? window : this, function (b) {
+}(typeof self !== 'undefined' ? self : this, function (b) {
     // Use b in some fashion.
 
     // Just return a value to define the module export.

--- a/templates/commonjsStrict.js
+++ b/templates/commonjsStrict.js
@@ -27,7 +27,7 @@
         // Browser globals
         factory((root.commonJsStrict = {}), root.b);
     }
-}(typeof window !== 'undefined' ? window : this, function (exports, b) {
+}(typeof self !== 'undefined' ? self : this, function (exports, b) {
     // Use b in some fashion.
 
     // attach properties to the exports object to define

--- a/templates/commonjsStrict.js
+++ b/templates/commonjsStrict.js
@@ -27,7 +27,7 @@
         // Browser globals
         factory((root.commonJsStrict = {}), root.b);
     }
-}(this, function (exports, b) {
+}(typeof window !== 'undefined' ? window : this, function (exports, b) {
     // Use b in some fashion.
 
     // attach properties to the exports object to define

--- a/templates/commonjsStrictGlobal.js
+++ b/templates/commonjsStrictGlobal.js
@@ -29,7 +29,7 @@
         // Browser globals
         factory((root.commonJsStrictGlobal = {}), root.b);
     }
-}(this, function (exports, b) {
+}(typeof window !== 'undefined' ? window : this, function (exports, b) {
     // Use b in some fashion.
 
     // attach properties to the exports object to define

--- a/templates/commonjsStrictGlobal.js
+++ b/templates/commonjsStrictGlobal.js
@@ -29,7 +29,7 @@
         // Browser globals
         factory((root.commonJsStrictGlobal = {}), root.b);
     }
-}(typeof window !== 'undefined' ? window : this, function (exports, b) {
+}(typeof self !== 'undefined' ? self : this, function (exports, b) {
     // Use b in some fashion.
 
     // attach properties to the exports object to define

--- a/templates/returnExports.js
+++ b/templates/returnExports.js
@@ -27,7 +27,7 @@
         // Browser globals (root is window)
         root.returnExports = factory(root.b);
     }
-}(this, function (b) {
+}(typeof window !== 'undefined' ? window : this, function (b) {
     // Use b in some fashion.
 
     // Just return a value to define the module export.
@@ -51,7 +51,7 @@
         // Browser globals (root is window)
         root.returnExports = factory();
   }
-}(this, function () {
+}(typeof window !== 'undefined' ? window : this, function () {
 
     // Just return a value to define the module export.
     // This example returns an object, but the module

--- a/templates/returnExports.js
+++ b/templates/returnExports.js
@@ -27,7 +27,7 @@
         // Browser globals (root is window)
         root.returnExports = factory(root.b);
     }
-}(typeof window !== 'undefined' ? window : this, function (b) {
+}(typeof self !== 'undefined' ? self : this, function (b) {
     // Use b in some fashion.
 
     // Just return a value to define the module export.
@@ -51,7 +51,7 @@
         // Browser globals (root is window)
         root.returnExports = factory();
   }
-}(typeof window !== 'undefined' ? window : this, function () {
+}(typeof self !== 'undefined' ? self : this, function () {
 
     // Just return a value to define the module export.
     // This example returns an object, but the module

--- a/templates/returnExportsGlobal.js
+++ b/templates/returnExportsGlobal.js
@@ -29,7 +29,7 @@
         // Browser globals
         root.returnExportsGlobal = factory(root.b);
     }
-}(typeof window !== 'undefined' ? window : this, function (b) {
+}(typeof self !== 'undefined' ? self : this, function (b) {
     // Use b in some fashion.
 
     // Just return a value to define the module export.

--- a/templates/returnExportsGlobal.js
+++ b/templates/returnExportsGlobal.js
@@ -29,7 +29,7 @@
         // Browser globals
         root.returnExportsGlobal = factory(root.b);
     }
-}(this, function (b) {
+}(typeof window !== 'undefined' ? window : this, function (b) {
     // Use b in some fashion.
 
     // Just return a value to define the module export.


### PR DESCRIPTION
In strict mode, `this` is no longer sufficient to detect the
global object. This change adapts the detection of the global object
for the case of exporting to the browser global object.

Fixes #124 

Note: this is but one potential strategy for correct global detection, and it explicitly supports the browser context. There are other (potentially more complicated) detections that will support non-browser contexts. Whether or not it is critical to support such contexts is a question I leave open for discussion.